### PR TITLE
CI: fix Android workflow and add gradle wrapper

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -29,29 +29,62 @@ jobs:
         run: |
           set -eux
           SDK_ROOT="$HOME/android-sdk"
-          - name: Set up Android SDK
-            uses: r0adkll/setup-android@v2
-            with:
-              api-level: 33
-              build-tools: 33.0.2
-              ndk: ''
-              components: |
-                platform-tools
-                platforms;android-33
-                build-tools;33.0.2
-      
-          - name: Install Gradle and build (generate wrapper if missing)
-            working-directory: android
-            run: |
-              set -eux
-              sudo apt-get update
-              sudo apt-get install -y gradle unzip
-              gradle --version
-              # If no gradlew exists, generate a wrapper using installed gradle
-              if [ ! -f ./gradlew ]; then
-                gradle wrapper --gradle-version 8.4.1
-              fi
-              chmod +x ./gradlew
-              ./gradlew assembleDebug --no-daemon --console=plain
-          name: android-apk
-          path: android/app/build/outputs/apk/debug/*.apk
+          name: Android CI - Build APK
+
+          on:
+            push:
+              branches: [ main ]
+            pull_request:
+              branches: [ main ]
+
+          jobs:
+            build:
+              runs-on: ubuntu-24.04
+              steps:
+                - uses: actions/checkout@v4
+
+                - name: Set up JDK
+                  uses: actions/setup-java@v4
+                  with:
+                    distribution: 'temurin'
+                    java-version: '17'
+
+                - name: Cache Gradle
+                  uses: actions/cache@v4
+                  with:
+                    path: |
+                      ~/.gradle/caches
+                      ~/.gradle/wrapper
+                    key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+                    restore-keys: |
+                      ${{ runner.os }}-gradle-
+
+                - name: Set up Android SDK
+                  uses: r0adkll/setup-android@v2
+                  with:
+                    api-level: 33
+                    build-tools: 33.0.2
+                    components: |
+                      platform-tools
+                      platforms;android-33
+                      build-tools;33.0.2
+
+                - name: Install Gradle and build (generate wrapper if missing)
+                  working-directory: android
+                  run: |
+                    set -eux
+                    sudo apt-get update
+                    sudo apt-get install -y gradle unzip
+                    gradle --version
+                    # If no gradlew exists, generate a wrapper using installed gradle
+                    if [ ! -f ./gradlew ]; then
+                      gradle wrapper --gradle-version 8.4.1
+                    fi
+                    chmod +x ./gradlew
+                    ./gradlew assembleDebug --no-daemon --console=plain
+
+                - name: Upload APK artifact
+                  uses: actions/upload-artifact@v4
+                  with:
+                    name: android-apk
+                    path: android/app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK
-        uses: actions/setup-java@v4
+      build:
+        runs-on: ubuntu-24.04
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -29,32 +29,29 @@ jobs:
         run: |
           set -eux
           SDK_ROOT="$HOME/android-sdk"
-          mkdir -p "$SDK_ROOT"
-          export ANDROID_SDK_ROOT="$SDK_ROOT"
-          # Download commandline tools (stable known URL may change; this one is commonly available)
-          CLI_ZIP="commandlinetools-linux_latest.zip"
-          curl -fsSL "https://dl.google.com/android/repository/commandlinetools-linux_latest.zip" -o /tmp/$CLI_ZIP
-          mkdir -p "$SDK_ROOT/cmdline-tools/latest"
-          unzip -q /tmp/$CLI_ZIP -d "$SDK_ROOT/cmdline-tools/latest"
-          export PATH="$SDK_ROOT/cmdline-tools/latest/cmdline-tools/bin:$PATH"
-          yes | sdkmanager --licenses || true
-          sdkmanager --sdk_root="$SDK_ROOT" "platform-tools" "platforms;android-33" "build-tools;33.0.2" "cmdline-tools;latest"
-          ls -la "$SDK_ROOT"
-
-      - name: Install Gradle and build (generate wrapper if missing)
-        run: |
-          set -eux
-          sudo apt-get update
-          sudo apt-get install -y gradle unzip
-          gradle --version
-          cd android
-          # If no gradlew exists, generate a wrapper using installed gradle
-          if [ ! -f ./gradlew ]; then
-            gradle wrapper
-          fi
-          ./gradlew assembleDebug --no-daemon --console=plain
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
-        with:
+          - name: Set up Android SDK
+            uses: r0adkll/setup-android@v2
+            with:
+              api-level: 33
+              build-tools: 33.0.2
+              ndk: ''
+              components: |
+                platform-tools
+                platforms;android-33
+                build-tools;33.0.2
+      
+          - name: Install Gradle and build (generate wrapper if missing)
+            working-directory: android
+            run: |
+              set -eux
+              sudo apt-get update
+              sudo apt-get install -y gradle unzip
+              gradle --version
+              # If no gradlew exists, generate a wrapper using installed gradle
+              if [ ! -f ./gradlew ]; then
+                gradle wrapper --gradle-version 8.4.1
+              fi
+              chmod +x ./gradlew
+              ./gradlew assembleDebug --no-daemon --console=plain
           name: android-apk
           path: android/app/build/outputs/apk/debug/*.apk

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4.1-bin.zip

--- a/android/gradlew
+++ b/android/gradlew
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+###############################################################################
+# Gradle start up script for UN*X
+###############################################################################
+set -e
+
+PRG="$0"
+while [ -h "$PRG" ] ; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`"/"`expr "$link" : '\(.*\)$'`
+  fi
+done
+
+PRGDIR=`dirname "$PRG"`
+exec  "${JAVA_HOME:-java}" -classpath "$PRGDIR/gradle/wrapper/gradle-wrapper.jar" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/android/gradlew.bat
+++ b/android/gradlew.bat
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+set DIR=%~dp0
+set CLASSPATH=%DIR%gradle\wrapper\gradle-wrapper.jar
+"%JAVA_HOME%\bin\java" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*


### PR DESCRIPTION
This PR updates the Android workflow to use r0adkll/setup-android, ensures the build runs in the android/ directory, and adds a Gradle wrapper fallback. Please run CI and merge when green.